### PR TITLE
Add workflow to publish to PyPI on version tag

### DIFF
--- a/.github/workflows/publish_to_pypi.yml
+++ b/.github/workflows/publish_to_pypi.yml
@@ -1,0 +1,26 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - 'v*.*.*'
+
+jobs:
+  build-and-publish:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout code
+      uses: actions/checkout@v3
+
+    - name: Setup
+      uses: './.github/actions/ci-setup'
+      id: setup
+      with:
+        python-version: '3.x'
+
+    - name: Build
+      run: poetry build
+
+    - name: Publish package to PyPI
+      run: poetry publish --username __token__ --password ${{ secrets.PYPI_API_TOKEN }}


### PR DESCRIPTION
Added `.github/workflows/publish_to_pypi.yml` workflow. The workflow runs when a tag with format `v*.*.*` is pushed to the repository (which occurs when a release is made and tagged appropriately). It runs `poetry build` and `poetry publish`, using the API key stored in the `PYPI_API_TOKEN` repository action secret.