### PR TITLE
Cache poetry and dependencies steps and pin poetry version in config file

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -22,14 +22,43 @@ runs:
         pipx ensurepath
       shell: bash
 
+    - name: Read Poetry Version
+      id: read-poetry-version
+      run: |
+        poetry_version=$(cat .github/actions/ci-setup/config.yml | grep poetry_version | awk '{print $2}')
+        echo "poetry_version=$poetry_version" >> $GITHUB_ENV
+      shell: bash
+
+    - name: Cache Poetry
+      id: cache-poetry
+      uses: actions/cache@v3
+      with:
+        path: ~/.cache/pypoetry
+        key: ${{ runner.os }}-poetry-${{ env.poetry_version }}
+        restore-keys: |
+          ${{ runner.os }}-poetry-
+
     - name: Install poetry
-      run: pipx install poetry==1.8.2
+      if: steps.cache-poetry.outputs.cache-hit != 'true'
+      run: pipx install poetry==${{ env.poetry_version }}
       shell: bash
 
     - name: Set python version
       run: poetry env use python
       shell: bash
 
+    - name: Cache Poetry Dependencies
+      id: cache-poetry-dependencies
+      uses: actions/cache@v3
+      with:
+        path: |
+          ~/.local/share/pypoetry/virtualenvs
+          **/poetry.lock
+        key: ${{ runner.os }}-poetry-dependencies-${{ hashFiles('**/pyproject.toml') }}
+        restore-keys: |
+          ${{ runner.os }}-poetry-dependencies-
+
     - name: Install dependencies
+      if: steps.cache-poetry-dependencies.outputs.cache-hit != 'true'
       run: poetry install
       shell: bash

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -44,6 +44,10 @@ runs:
       run: pipx install poetry==${{ env.poetry_version }}
       shell: bash
 
+    - name: Configure Poetry
+      run: poetry config virtualenvs.in-project true
+      shell: bash
+
     - name: Set python version
       run: poetry env use python
       shell: bash

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -36,8 +36,6 @@ runs:
       with:
         path: ~/.local
         key: ${{ runner.os }}-poetry-${{ env.poetry_version }}
-        restore-keys: |
-          ${{ runner.os }}-poetry-
 
     - name: Install poetry
       if: steps.cache-poetry.outputs.cache-hit != 'true'
@@ -61,8 +59,6 @@ runs:
           **/poetry.lock
           .venv
         key: ${{ runner.os }}-poetry-dependencies-${{ hashFiles('**/pyproject.toml') }}
-        restore-keys: |
-          ${{ runner.os }}-poetry-dependencies-
 
     - name: Install dependencies
       if: steps.cache-poetry-dependencies.outputs.cache-hit != 'true'

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -16,6 +16,7 @@ runs:
       with:
         python-version: ${{ inputs.python-version }}
 
+
     - name: Install pipx
       run: |
         sudo apt install pipx
@@ -52,7 +53,7 @@ runs:
       uses: actions/cache@v3
       with:
         path: |
-          ~/.local/share/pypoetry/virtualenvs
+          ~/.local
           **/poetry.lock
         key: ${{ runner.os }}-poetry-dependencies-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -42,6 +42,10 @@ runs:
       run: pipx install poetry==${{ env.poetry_version }}
       shell: bash
 
+    - name: Add poetry to PATH
+      run: echo "export PATH=$PATH:$HOME/.local/bin" >> $GITHUB_ENV
+      shell: bash
+
     - name: Configure Poetry
       run: poetry config virtualenvs.in-project true
       shell: bash

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -34,7 +34,7 @@ runs:
       id: cache-poetry
       uses: actions/cache@v3
       with:
-        path: ~/.cache/pypoetry
+        path: ~/.local
         key: ${{ runner.os }}-poetry-${{ env.poetry_version }}
         restore-keys: |
           ${{ runner.os }}-poetry-

--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -55,6 +55,7 @@ runs:
         path: |
           ~/.local
           **/poetry.lock
+          .venv
         key: ${{ runner.os }}-poetry-dependencies-${{ hashFiles('**/pyproject.toml') }}
         restore-keys: |
           ${{ runner.os }}-poetry-dependencies-

--- a/.github/actions/ci-setup/config.yml
+++ b/.github/actions/ci-setup/config.yml
@@ -1,0 +1,1 @@
+poetry_version: "1.8.2"


### PR DESCRIPTION
Caching poetry installation and poetry environment setup steps in the ci-setup.

The poetry version is pinned using the config file: `.github/actions/ci-setup/config.yml`. If this file changes then this triggers a cache miss and a fresh installation of poetry is made.

The `pyproject.toml` file is used as the key for the Poetry environment setup, so there's a cache miss if the environment changes.