### PR TITLE
Feature/ignore response codes

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,16 +22,33 @@ Simply provide the URL of the sitemap and `pylich` will crawl through links in t
 ### Command Line
 
 ```bash
-pylich https://www.example.com/sitemap.xml -v
+pylich https://www.example.com/sitemap.xml
 ```
 
-The `-v` verbosity flag is optional and will print progress to the console as well as a summary of the dead links at the end. The command will exit with a status code of 1 if any dead links are found and 0 otherwise.
+The command will exit with a status code of 1 if any dead links are found and 0 otherwise.
+
+#### Options
+
+| Flag | Arguments | Description |
+| --- | --- | --- |
+| `-v` | N/A | Verbose mode. Print progress to the console as well as a summary of the dead links at the end. |
+| `-i` | List of integer HTTP response codes | Ignore links with the specified HTTP response codes. |
+
+```bash
+pylich https://www.example.com/sitemap.xml -v -i 404 500
+```
 
 ### Python Package
 
+PyLich can also be used as a Python package. 
+
 ```python
 from pylich import LinkChecker
-checker = LinkChecker("https://www.example.com/sitemap.xml", verbose=True)
+checker = LinkChecker(
+    "https://www.example.com/sitemap.xml",
+    verbose=True,
+    ignored_status_codes=[404, 500]
+)
 urls = checker.get_sitemap_urls()
 broken_links = checker.check_links(urls)
 checker.print_dead_links()

--- a/pylich/cli.py
+++ b/pylich/cli.py
@@ -16,11 +16,21 @@ def main():
         action="store_true",
         help="Increase output verbosity",
     )
+    parser.add_argument(
+        "-i",
+        "--ignore-status-codes",
+        type=int,
+        nargs="*",
+        default=[],
+        help="List of HTTP status codes to ignore",
+    )
     args = parser.parse_args()
 
     try:
         checker = LinkChecker(
-            sitemap_url=args.sitemap_url, verbose=args.verbose
+            sitemap_url=args.sitemap_url,
+            verbose=args.verbose,
+            ignored_status_codes=args.ignore_status_codes,
         )
         urls = checker.get_sitemap_urls()
         broken_links = checker.check_links(urls)
@@ -32,7 +42,10 @@ def main():
             sys.exit(1)
         else:
             if args.verbose:
-                print("No broken links found")
+                if checker.ignored_links:
+                    checker.print_dead_links()
+                else:
+                    print("No broken links found")
             sys.exit(0)
     except Exception as e:
         print(f"Error: {e}")


### PR DESCRIPTION
Add functionality to optionally specify a list of HTTP response codes to ignore. For example, might want to ignore "403 forbidden" responses and not count them as broken links.

Python API usage:

```python
checker = LinkChecker(
    "https://www.example.com/sitemap.xml",
    ignored_status_codes=[404, 500]
)
```

CLI usage:

```bash
pylich https://www.example.com/sitemap.xml -i 404 500
```

Added tests and documentation.