### PR TITLE
Configure poetry to create virtualenvs in project

### DIFF
--- a/.github/actions/ci-setup/action.yml
+++ b/.github/actions/ci-setup/action.yml
@@ -38,6 +38,10 @@ runs:
         virtualenvs-create: true
         virtualenvs-in-project: true
 
+    - name: Configure poetry
+      run: poetry config virtualenvs.in-project true
+      shell: bash
+
     - name: Set python version
       run: poetry env use python
       shell: bash


### PR DESCRIPTION
Caching of virtual environment currently fails when poetry is not restored from cache. I suspect this is because the poetry installation step is skipped so poetry installs virtual environments in the default location, which is not `.venv/`.